### PR TITLE
Fix mocharc prettier

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,12 +1,8 @@
 {
-  "extensions": [
-    "ts"
-  ],
+  "extensions": ["ts"],
   "timeout": 5000,
   "spec": "test/*.test.ts",
-  "file": [
-    "test/setup.ts"
-  ],
+  "file": ["test/setup.ts"],
   "loader": "ts-node/esm",
   "node-option": [
     "experimental-specifier-resolution=node",


### PR DESCRIPTION
I noticed the the dependabot PRs are not passing the prettier check, and it looks to be coming from the mocharc formatting.
This PR is the result of running `npm run prettier:fix`