### PR TITLE
Fix hanging c8 coverage script

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 /dist/
+/coverage/

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "format": "npm run prettier:fix && npm run lint:fix",
     "prepublishOnly": "npm run build",
     "test": "mocha",
-    "coverage": "c8 mocha",
+    "coverage": "c8 mocha --exit",
     "clean": "rm -rf dist",
     "build": "npx tsc"
   },


### PR DESCRIPTION
Not entirely sure why mocha needs the --exit flag for c8 coverage to work, but this get the `npm run coverage` script working again.
Also, added the coverage dir to the .pretterignore file